### PR TITLE
A-CodeQuality: Unify CLI/GUI logic via ChattyCore

### DIFF
--- a/src/main/java/chatty/app/ChattyBot.java
+++ b/src/main/java/chatty/app/ChattyBot.java
@@ -1,140 +1,34 @@
 package chatty.app;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import chatty.exceptions.ChattyException;
-import chatty.exceptions.EmptyDescriptionException;
-import chatty.exceptions.MalformedArgumentsException;
-import chatty.parser.Parser;
-import chatty.storage.Storage;
-import chatty.task.Deadline;
-import chatty.task.Event;
-import chatty.task.Task;
-import chatty.task.TaskList;
-import chatty.task.Todo;
 import chatty.ui.Ui;
 
-/**
- * CLI entry point for ChattyBot.
- * Uses Ui to format messages and prints them to stdout.
- */
+/** Main class for the ChattyBot application. */
 public class ChattyBot {
-    private final Ui ui;
-    private final Storage storage;
-    private final TaskList tasks;
+    private final ChattyCore core;
 
-    /**
-     * Constructs a new ChattyBot instance.
-     * Initializes the UI, storage, and task list.
-     */
+    /** Constructor for ChattyBot. */
     public ChattyBot() {
-        this.ui = new Ui();
-        this.storage = new Storage();
-        ArrayList<Task> seed = storage.load();
-        this.tasks = new TaskList(seed);
+        this.core = new ChattyCore();
     }
 
-    /**
-     * Runs the ChattyBot application.
-     * Handles user input and executes commands until the user exits.
-     */
+    /** Runs the ChattyBot application. */
     public void run() {
-        System.out.println(ui.box(ui.showWelcome()));
+        System.out.println(core.greeting());
 
+        Ui ui = new Ui();
         while (true) {
             String input = ui.readCommand();
-            try {
-                Parser.Parsed p = Parser.parse(input);
+            String reply = core.process(input);
+            System.out.println(reply);
 
-                switch (p.cmd()) {
-                case BYE: {
-                    System.out.println(ui.box(ui.showBye()));
-                    ui.close();
-                    return;
-                }
-                case LIST: {
-                    System.out.println(ui.box(ui.showList(tasks)));
-                    break;
-                }
-                case MARK: {
-                    int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
-                    Task t = tasks.get(idx);
-                    t.mark();
-                    storage.save(tasks.asList());
-                    System.out.println(ui.box(ui.showMarked(t)));
-                    break;
-                }
-                case UNMARK: {
-                    int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
-                    Task t = tasks.get(idx);
-                    t.unmark();
-                    storage.save(tasks.asList());
-                    System.out.println(ui.box(ui.showUnmarked(t)));
-                    break;
-                }
-                case DELETE: {
-                    if (p.args().isEmpty()) {
-                        throw new ChattyException("Task number is missing.");
-                    }
-                    int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
-                    Task removed = tasks.remove(idx);
-                    storage.save(tasks.asList());
-                    System.out.println(ui.box(ui.showDeleted(removed, tasks.size())));
-                    break;
-                }
-                case TODO: {
-                    if (p.args().isEmpty()) {
-                        throw new EmptyDescriptionException("a todo");
-                    }
-                    Task t = new Todo(p.args());
-                    tasks.add(t);
-                    storage.save(tasks.asList());
-                    System.out.println(ui.box(ui.showAdded(t, tasks.size())));
-                    break;
-                }
-                case DEADLINE: {
-                    if (p.args().isEmpty()) {
-                        throw new MalformedArgumentsException("deadline <desc> /by dd-MM-yyyy HHmm");
-                    }
-                    String[] parts = Parser.splitDeadlineArgs(p.args());
-                    Task t = new Deadline(parts[0], parts[1]);
-                    tasks.add(t);
-                    storage.save(tasks.asList());
-                    System.out.println(ui.box(ui.showAdded(t, tasks.size())));
-                    break;
-                }
-                case EVENT: {
-                    if (p.args().isEmpty()) {
-                        throw new MalformedArgumentsException("event <desc> /from dd-MM-yyyy HHmm /to dd-MM-yyyy HHmm");
-                    }
-                    String[] parts = Parser.splitEventArgs(p.args());
-                    Task t = new Event(parts[0], parts[1], parts[2]);
-                    tasks.add(t);
-                    storage.save(tasks.asList());
-                    System.out.println(ui.box(ui.showAdded(t, tasks.size())));
-                    break;
-                }
-                case FIND: {
-                    if (p.args().isEmpty()) {
-                        throw new MalformedArgumentsException("find <keyword>");
-                    }
-                    List<Task> matches = tasks.find(p.args());
-                    System.out.println(ui.box(ui.showMatches(matches)));
-                    break;
-                }
-                default: {
-                    throw new ChattyException("Unknown command encountered: " + p.cmd());
-                }
-                }
-            } catch (ChattyException e) {
-                System.out.println(ui.box(ui.showError(e.getMessage())));
-            } catch (NumberFormatException | IndexOutOfBoundsException e) {
-                System.out.println(ui.box(ui.showError("Please provide a valid task number within range.")));
+            if ("bye".equalsIgnoreCase(input.trim())) {
+                ui.close();
+                return;
             }
         }
     }
 
+    /** Main method to start the ChattyBot application. */
     public static void main(String[] args) {
         new ChattyBot().run();
     }

--- a/src/main/java/chatty/app/ChattyCore.java
+++ b/src/main/java/chatty/app/ChattyCore.java
@@ -1,0 +1,115 @@
+package chatty.app;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import chatty.exceptions.ChattyException;
+import chatty.exceptions.EmptyDescriptionException;
+import chatty.exceptions.MalformedArgumentsException;
+import chatty.parser.Parser;
+import chatty.storage.Storage;
+import chatty.task.Deadline;
+import chatty.task.Event;
+import chatty.task.Task;
+import chatty.task.TaskList;
+import chatty.task.Todo;
+import chatty.ui.Ui;
+
+/** Core logic for ChattyBot. */
+public class ChattyCore {
+    private final Ui ui;
+    private final Storage storage;
+    private final TaskList tasks;
+
+    /** Constructor for ChattyCore. */
+    public ChattyCore() {
+        this.ui = new Ui();
+        this.storage = new Storage();
+        ArrayList<Task> seed = storage.load();
+        this.tasks = new TaskList(seed);
+    }
+
+    /** Process one line of user input, return bot’s reply. */
+    public String process(String input) {
+        try {
+            Parser.Parsed p = Parser.parse(input);
+
+            switch (p.cmd()) {
+            case BYE:
+                return ui.showBye();
+            case LIST:
+                return ui.showList(tasks);
+            case MARK: {
+                int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
+                Task t = tasks.get(idx);
+                t.mark();
+                storage.save(tasks.asList());
+                return ui.showMarked(t);
+            }
+            case UNMARK: {
+                int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
+                Task t = tasks.get(idx);
+                t.unmark();
+                storage.save(tasks.asList());
+                return ui.showUnmarked(t);
+            }
+            case DELETE: {
+                if (p.args().isEmpty()) {
+                    throw new ChattyException("Task number is missing.");
+                }
+                int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
+                Task removed = tasks.remove(idx);
+                storage.save(tasks.asList());
+                return ui.showDeleted(removed, tasks.size());
+            }
+            case TODO: {
+                if (p.args().isEmpty()) {
+                    throw new EmptyDescriptionException("a todo");
+                }
+                Task t = new Todo(p.args());
+                tasks.add(t);
+                storage.save(tasks.asList());
+                return ui.showAdded(t, tasks.size());
+            }
+            case DEADLINE: {
+                if (p.args().isEmpty()) {
+                    throw new MalformedArgumentsException("deadline <desc> /by dd-MM-yyyy HHmm");
+                }
+                String[] parts = Parser.splitDeadlineArgs(p.args());
+                Task t = new Deadline(parts[0], parts[1]);
+                tasks.add(t);
+                storage.save(tasks.asList());
+                return ui.showAdded(t, tasks.size());
+            }
+            case EVENT: {
+                if (p.args().isEmpty()) {
+                    throw new MalformedArgumentsException("event <desc> /from dd-MM-yyyy HHmm /to dd-MM-yyyy HHmm");
+                }
+                String[] parts = Parser.splitEventArgs(p.args());
+                Task t = new Event(parts[0], parts[1], parts[2]);
+                tasks.add(t);
+                storage.save(tasks.asList());
+                return ui.showAdded(t, tasks.size());
+            }
+            case FIND: {
+                if (p.args().isEmpty()) {
+                    throw new MalformedArgumentsException("find <keyword>");
+                }
+                List<Task> matches = tasks.find(p.args());
+                return ui.showMatches(matches);
+            }
+            default:
+                throw new ChattyException("Unknown command encountered: " + p.cmd());
+            }
+
+        } catch (ChattyException e) {
+            return ui.showError(e.getMessage());
+        } catch (NumberFormatException | IndexOutOfBoundsException e) {
+            return ui.showError("Please provide a valid task number within range.");
+        }
+    }
+    /** Shared greeting */
+    public String greeting() {
+        return ui.showWelcome();
+    }
+}

--- a/src/main/java/chatty/app/ChattyEngine.java
+++ b/src/main/java/chatty/app/ChattyEngine.java
@@ -1,119 +1,21 @@
 package chatty.app;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import chatty.exceptions.ChattyException;
-import chatty.exceptions.EmptyDescriptionException;
-import chatty.exceptions.MalformedArgumentsException;
-import chatty.parser.Parser;
-import chatty.storage.Storage;
-import chatty.task.Deadline;
-import chatty.task.Event;
-import chatty.task.Task;
-import chatty.task.TaskList;
-import chatty.task.Todo;
-
-/**
- * Core engine for ChattyBot.
- * - Returns formatted strings (via Ui) for GUI.
- * - GUI calls handleInput(...) with user’s text and gets back bot’s reply string.
- */
+/** Engine for ChattyBot. */
 public class ChattyEngine {
-    private final Storage storage;
-    private final TaskList tasks;
-    private final chatty.ui.Ui ui; // reusing same Ui for formatting
+    private final ChattyCore core;
 
-    /** Initializes ChattyBot with saved tasks. */
+    /** Constructor for ChattyEngine. */
     public ChattyEngine() {
-        this.ui = new chatty.ui.Ui();
-        this.storage = new Storage();
-        ArrayList<Task> seed = storage.load();
-        this.tasks = new TaskList(seed);
+        this.core = new ChattyCore();
     }
 
-    /** Handles one user input and returns ChattyBot’s reply string. */
+    /** Handles user input and returns a reply. */
     public String handleInput(String input) {
-        try {
-            Parser.Parsed p = Parser.parse(input);
-
-            switch (p.cmd()) {
-            case BYE:
-                return ui.showBye();
-            case LIST:
-                return ui.showList(tasks);
-            case MARK: {
-                int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
-                Task t = tasks.get(idx);
-                t.mark();
-                storage.save(tasks.asList());
-                return ui.showMarked(t);
-            }
-            case UNMARK: {
-                int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
-                Task t = tasks.get(idx);
-                t.unmark();
-                storage.save(tasks.asList());
-                return ui.showUnmarked(t);
-            }
-            case DELETE: {
-                if (p.args().isEmpty()) {
-                    throw new ChattyException("Task number is missing.");
-                }
-                int idx = Parser.parseIndexOrThrow(p.args(), tasks.size());
-                Task removed = tasks.remove(idx);
-                storage.save(tasks.asList());
-                return ui.showDeleted(removed, tasks.size());
-            }
-            case TODO: {
-                if (p.args().isEmpty()) {
-                    throw new EmptyDescriptionException("a todo");
-                }
-                Task t = new Todo(p.args());
-                tasks.add(t);
-                storage.save(tasks.asList());
-                return ui.showAdded(t, tasks.size());
-            }
-            case DEADLINE: {
-                if (p.args().isEmpty()) {
-                    throw new MalformedArgumentsException("deadline <desc> /by dd-MM-yyyy HHmm");
-                }
-                String[] parts = Parser.splitDeadlineArgs(p.args());
-                Task t = new Deadline(parts[0], parts[1]);
-                tasks.add(t);
-                storage.save(tasks.asList());
-                return ui.showAdded(t, tasks.size());
-            }
-            case EVENT: {
-                if (p.args().isEmpty()) {
-                    throw new MalformedArgumentsException("event <desc> /from dd-MM-yyyy HHmm /to dd-MM-yyyy HHmm");
-                }
-                String[] parts = Parser.splitEventArgs(p.args());
-                Task t = new Event(parts[0], parts[1], parts[2]);
-                tasks.add(t);
-                storage.save(tasks.asList());
-                return ui.showAdded(t, tasks.size());
-            }
-            case FIND: {
-                if (p.args().isEmpty()) {
-                    throw new MalformedArgumentsException("find <keyword>");
-                }
-                List<Task> matches = tasks.find(p.args());
-                return ui.showMatches(matches);
-            }
-            default:
-                throw new ChattyException("Unknown command encountered: " + p.cmd());
-            }
-
-        } catch (ChattyException e) {
-            return ui.showError(e.getMessage());
-        } catch (NumberFormatException | IndexOutOfBoundsException e) {
-            return ui.showError("Please provide a valid task number within range.");
-        }
+        return core.process(input);
     }
 
-    /** For GUI: initial greeting */
+    /** Returns the greeting message. */
     public String getGreeting() {
-        return ui.showWelcome();
+        return core.greeting();
     }
 }

--- a/src/main/java/chatty/exceptions/UnknownCommandException.java
+++ b/src/main/java/chatty/exceptions/UnknownCommandException.java
@@ -20,6 +20,16 @@ public class UnknownCommandException extends ChattyException {
      * @see Throwable
      */
     public UnknownCommandException(String input) {
-        super("I'm sorry, I don't recognize the command: \"" + input + "\"");
+        super("I'm sorry, I don't recognize the command: \"" + input + "\"" + "\n\n"
+            + "Here are the available commands:\n"
+            + " 1. list\n"
+            + " 2. mark <index>\n"
+            + " 3. unmark <index>\n"
+            + " 4. delete <index>\n"
+            + " 5. todo <description>\n"
+            + " 6. deadline <description> /by <dd-MM-yyyy HHmm>\n"
+            + " 7. event <description> /from <dd-MM-yyyy HHmm> /to <dd-MM-yyyy HHmm>\n"
+            + " 8. find <keyword>\n"
+            + " 9. bye (EXIT)");
     }
 }

--- a/src/main/java/chatty/ui/Main.java
+++ b/src/main/java/chatty/ui/Main.java
@@ -1,5 +1,7 @@
 package chatty.ui;
 
+import java.util.Objects;
+
 import chatty.app.ChattyEngine;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
@@ -10,6 +12,8 @@ import javafx.stage.Stage;
 
 /** A GUI for ChattyBot using FXML. */
 public class Main extends Application {
+
+    private static final String ICON_PHOTO = "/images/icon.png";
 
     @Override
     public void start(Stage stage) {
@@ -23,7 +27,7 @@ public class Main extends Application {
 
             Scene scene = new Scene(root);
             stage.setTitle("ChattyBot");
-            stage.getIcons().add(new Image(this.getClass().getResourceAsStream("/images/icon.png")));
+            stage.getIcons().add(new Image(Objects.requireNonNull(this.getClass().getResourceAsStream(ICON_PHOTO))));
             stage.setResizable(false);
             stage.setScene(scene);
 

--- a/src/main/java/chatty/ui/MainWindow.java
+++ b/src/main/java/chatty/ui/MainWindow.java
@@ -1,5 +1,7 @@
 package chatty.ui;
 
+import java.util.Objects;
+
 import chatty.app.ChattyEngine;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -11,6 +13,9 @@ import javafx.scene.layout.VBox;
 /** Controller for the main GUI window. */
 public class MainWindow {
 
+    private static final String BOT_PHOTO = "/images/DaDuke.png";
+    private static final String USER_PHOTO = "/images/DaUser.png";
+
     @FXML private ScrollPane scrollPane;
     @FXML private VBox dialogContainer;
     @FXML private TextField userInput;
@@ -19,9 +24,9 @@ public class MainWindow {
     private ChattyEngine engine;
 
     private final Image userImage =
-            new Image(this.getClass().getResourceAsStream("/images/DaUser.png"));
+            new Image(Objects.requireNonNull(this.getClass().getResourceAsStream(USER_PHOTO)));
     private final Image botImage =
-            new Image(this.getClass().getResourceAsStream("/images/DaDuke.png"));
+            new Image(Objects.requireNonNull(this.getClass().getResourceAsStream(BOT_PHOTO)));
 
     /** Called by JavaFX after @FXML members are injected. */
     @FXML


### PR DESCRIPTION
ChattyEngine and ChattyBot duplicate command handling logic, causing code drift risk and making future changes harder to implement and test.

Unifying the execution flow improves maintainability and supports subsequent extractions without changing external behavior.

Let's
* introduce ChattyCore as the single entry point for processing input
* route both GUI and CLI through ChattyCore to eliminate duplication
* return reply strings from ChattyCore instead of printing internally
* provide a helpful list of available commands on unknown input

This refactor preserves behavior while clarifying responsibilities: frontends display replies; ChattyCore parses, mutates tasks, and formats responses. It sets the stage for consolidating persistence policy and extracting per-command classes in follow-up commits.